### PR TITLE
Remove MVP Award Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,23 +78,23 @@ Let us know that you are a Microsoft MVP using the `IAmAMicrosoftMVP` interface.
 Planet PowerShell is all about PowerShell content. To ensure that the feed only contains relevant content you can implement the `IFilterMyBlogPosts` interface on your author class.
 
 ``` csharp
-public class BruceWayne : IAmACommunityMember, IFilterMyBlogPosts
-{
-    // ... Author properties from the above class, removed for brevity
-
-    public bool Filter(SyndicationItem item)
+    public class BruceWayne : IAmACommunityMember, IFilterMyBlogPosts
     {
-        // Here you filter out the given item by the criteria you want, i.e.
-        // this filters out posts that do not have PowerShell in the title
-        return item.Title.Text.ToLowerInvariant().Contains("powershell");
-        
-        // This filters out only the posts that have the "PowerShell" category
-        return item.Categories.Any(c => c.Name.ToLowerInvariant().Equals("powershell"));
-        
-        // Of course you can make the checks as complicated as you want and combine some stuff
-        return item.Title.Text.ToLowerInvariant().Contains("powershell") && item.Categories.Any(c => c.Name.ToLowerInvariant().Equals("powershell"));
+        // ... Author properties from the above class, removed for brevity
+
+        public bool Filter(SyndicationItem item)
+        {
+            // Here you filter out the given item by the criteria you want, i.e.
+            // this filters out posts that do not have PowerShell in the title
+            return item.Title.Text.ToLowerInvariant().Contains("powershell");
+            
+            // This filters out only the posts that have the "PowerShell" category
+            return item.Categories.Any(c => c.Name.ToLowerInvariant().Equals("powershell"));
+            
+            // Of course you can make the checks as complicated as you want and combine some stuff
+            return item.Title.Text.ToLowerInvariant().Contains("powershell") && item.Categories.Any(c => c.Name.ToLowerInvariant().Equals("powershell"));
+        }
     }
-}
 ```
 
 ## A small step for an author...

--- a/src/Firehose.Web/Authors/DavidOBrien.cs
+++ b/src/Firehose.Web/Authors/DavidOBrien.cs
@@ -31,8 +31,6 @@ namespace Firehose.Web.Authors
             return item.Categories.Where(i => i.Name.Equals("powershell", StringComparison.OrdinalIgnoreCase)).Any();
         }
 
-        public GeoPosition Position => new GeoPosition(-37.8136,144.9631);
-        
-        DateTime IAmAMicrosoftMVP.FirstAwarded => new DateTime(2012, 10, 1);
+        public GeoPosition Position => new GeoPosition(-37.8136,144.9631);       
     }
 }

--- a/src/Firehose.Web/Authors/DougFinke.cs
+++ b/src/Firehose.Web/Authors/DougFinke.cs
@@ -32,7 +32,5 @@ namespace Firehose.Web.Authors
         }
 
         public GeoPosition Position => new GeoPosition(40.7526970, -73.9749950);
-        
-        DateTime IAmAMicrosoftMVP.FirstAwarded => new DateTime(2008, 4, 1);
     }
 }

--- a/src/Firehose.Web/Authors/JeffHicks.cs
+++ b/src/Firehose.Web/Authors/JeffHicks.cs
@@ -32,7 +32,5 @@ namespace Firehose.Web.Authors
         }
 
         public GeoPosition Position => new GeoPosition(43.035234,-76.13928);
-        
-        DateTime IAmAMicrosoftMVP.FirstAwarded => new DateTime(2007 , 7, 1);
     }
 }

--- a/src/Firehose.Web/Authors/QuintenSteenhuis.cs
+++ b/src/Firehose.Web/Authors/QuintenSteenhuis.cs
@@ -23,7 +23,7 @@ namespace Firehose.Web.Authors
         public IEnumerable<Uri> FeedUris { get { yield return new Uri("https://nonprofittechy.blogspot.com/feeds/posts/default"); } }
 
 	public bool Filter(SyndicationItem item)
-	    {
+	{
 		return item.Categories.Any(c => c.Name.ToLowerInvariant().Equals("powershell"));
 	}
 

--- a/src/Firehose.Web/Authors/WarrenFrame.cs
+++ b/src/Firehose.Web/Authors/WarrenFrame.cs
@@ -18,7 +18,6 @@ namespace Firehose.Web.Authors
         public string GitHubHandle => "ramblingcookiemonster";
         public string GravatarHash => "";
         public GeoPosition Position => new GeoPosition(42.3391000, -71.1206200);
-        DateTime IAmAMicrosoftMVP.FirstAwarded => new DateTime(2016, 1, 1);
 
         public Uri WebSite => new Uri("http://ramblingcookiemonster.github.io/");
         public IEnumerable<Uri> FeedUris { get { yield return new Uri("http://ramblingcookiemonster.github.io/feed.xml"); } }

--- a/src/Firehose.Web/Infrastructure/IAmABlogger.cs
+++ b/src/Firehose.Web/Infrastructure/IAmABlogger.cs
@@ -38,6 +38,5 @@ namespace Firehose.Web.Infrastructure
 
     public interface IAmAMicrosoftMVP : IAmACommunityMember
     {
-        DateTime FirstAwarded { get; }
     }
 }


### PR DESCRIPTION
MVP Award Date entries isn't used, and really isn't something that we need to display or store.

This was already removed from Planet Xamarin, but the readme wasn't updated. I then re-added it. 

Let's remove it.