### PR TITLE
Include author files in the .csproj by convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ This site couldn't have been made without the help of Readify and the Planet Xam
 - Your blog may be removed at any time if any of these are broken.
 
 ## How to add yourself
-Addin yourself as an author is easy! All you need to do is fork this project, add yourself to the [author folder] as your very own class. You need to ensure that you implement the `IAmACommunityMember` interface.
+Adding yourself as an author is easy! All you need to do is fork this project, and add a file to the `src\Firehose.Web\Authors\` folder.
 
-You can even do this via the GitHub editor, just don't forget to _add the class to the .csproj_ file. If you have never done anything like this, there are plenty of people that can help!
+The author file is a C# class that implements the `IAmACommunityMember` interface. It doesn't matter if you don't know C# though: just follow the many examples already there.
+
+You can even do this via the GitHub editor. If you have never done anything like this, there are plenty of people that can help!
 
 The result should look something like this:
 
@@ -43,7 +45,8 @@ The result should look something like this:
     }
 ```
 
-A few things: 
+A few things:
+- Don't worry about touching the `.csproj` file; it'll pick up the author file from the folder automatically
 - Name the class after your first and lastname with CamelCase
 - The `FirstName` and `LastName` property should resemble that same name
 - `ShortBioOrTagLine` property can be whatever you like. If you can't think of anything choose: 'software engineer' or 'software engineer at Microsoft'
@@ -57,7 +60,7 @@ A few things:
 
 If you also do some blogging about other stuff, no worries! You're fine! Just have a look at the next section on how to filter out your PowerShell specific posts.
 
-###Special note for Microsoft MVPs
+### Special note for Microsoft MVPs
 Let us know that you are a Microsoft MVP using the `IAmAMicrosoftMVP` interface.
 ``` csharp
     public class MVPGuy : IAmAMicrosoftMVP

--- a/src/Firehose.Web/Firehose.Web.csproj
+++ b/src/Firehose.Web/Firehose.Web.csproj
@@ -240,8 +240,6 @@
     <Compile Include="App_Start\ContainerConfig.cs" />
     <Compile Include="App_Start\IoC.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
-    <Compile Include="Authors\CraigGumbley.cs" />
-    <Compile Include="Authors\DavidChristian.cs" />
     <Compile Include="AutofacModules\FeedsModule.cs" />
     <Compile Include="AutofacModules\WebModule.cs" />
     <Compile Include="Controllers\BaseController.cs" />
@@ -261,47 +259,7 @@
     <Compile Include="Infrastructure\Md5HashingExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ViewModels\PreviewViewModel.cs" />
-    <!-- Include your authors here -->
-    <Compile Include="Authors\KieranJacobsen.cs" />
-    <Compile Include="Authors\SebastianFeldmann.cs" />
-    <Compile Include="Authors\FrancisSetash.cs" />
-    <Compile Include="Authors\NicholasMGetchell.cs" />
-    <Compile Include="Authors\MathieuBuisson.cs" />
-    <Compile Include="Authors\StephenOwen.cs" />
-    <Compile Include="Authors\WarrenFrame.cs" />
-    <Compile Include="Authors\ThomasRayner.cs" />
-    <Compile Include="Authors\MarkWragg.cs" />
-    <compile Include="Authors\JeffHicks.cs" />
-    <Compile Include="Authors\QuintenSteenhuis.cs" />
-    <compile Include="Authors\DavidOBrien.cs" />
-    <compile Include="Authors\GlennSarti.cs" />
-    <Compile Include="Authors\GrahamBeer.cs" />
-    <compile Include="Authors\SvenVanRijen.cs" />
-    <compile Include="Authors\RobSewell.cs" />
-    <compile Include="Authors\MikeFRobbins.cs" />
-    <Compile Include="Authors\DavidHall.cs" />
-    <compile Include="Authors\MattMcNabb.cs" />
-    <compile Include="Authors\ChrisHunt.cs" />
-    <compile Include="Authors\DougFinke.cs" />
-    <compile Include="Authors\JanEgilRing.cs" />
-    <compile Include="Authors\KevinMarquette.cs" />
-    <compile Include="Authors\MukeshShende.cs" />
-    <compile Include="Authors\ToreGroneng.cs" />
-    <compile Include="Authors\JaapBrasser.cs" />
-    <Compile Include="Authors\JoshDuffney.cs" />
-    <compile Include="Authors\AdamBertram.cs" />
-    <Compile Include="Authors\RyanMilne.cs" />
-    <Compile Include="Authors\JoshKing.cs" />
-    <Compile Include="Authors\BrandonPadgett.cs" />
-    <Compile Include="Authors\AndreasBittner.cs" />
-    <Compile Include="Authors\JonathanMedd.cs" />
-    <Compile Include="Authors\PrateekSingh.cs" />
-    <Compile Include="Authors\MikeShepard.cs" />
-    <Compile Include="Authors\BrianBunke.cs" />
-    <Compile Include="Authors\BoeProx.cs" />
-    <Compile Include="Authors\SergeyVasin.cs" />
-    <Compile Include="Authors\AaronNelson.cs" />
-    <Compile Include="Authors\AlexNeihaus.cs" />
+    <Compile Include="Authors\*.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\web.config" />


### PR DESCRIPTION
This makes it easier to add authors, by not requiring anybody to touch the `.csproj` file. Instead, the project just automatically includes everything in `src\Firehose.Web\Authors\*.cs` by convention.

This syntax has been supported in `.csproj` files for eons, but just never offered by the IDE. Older versions of VS used to read it in, determine all of the files once, then re-write the full list on save. VS2017 doesn't do this: it'll preserve the generic inclusion, even when people make other changes to the project.
