### PR TITLE
Introduce TLS 1.2 support

### DIFF
--- a/src/Firehose.Web/Infrastructure/CombinedFeedSource.cs
+++ b/src/Firehose.Web/Infrastructure/CombinedFeedSource.cs
@@ -29,6 +29,10 @@ namespace Firehose.Web.Infrastructure
             Bloggers = bloggers;
             var cached = new Cached<ISyndicationFeedSource>(TimeSpan.FromHours(1), new SystemClock(), LoadFeeds);
             _combinedFeedSource = new Lazy<Cached<ISyndicationFeedSource>>(() => cached, LazyThreadSafetyMode.PublicationOnly);
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 |
+                                                              SecurityProtocolType.Tls | SecurityProtocolType.Ssl3;
+
             HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PlanetXamarin", $"{GetType().Assembly.GetName().Version}"));
             HttpClient.Timeout = TimeSpan.FromMinutes(1);
         }


### PR DESCRIPTION
These are my Pull Requests (Git config was corrupted).

I missed the line adding TLS 1.2 when merging the changes from Planet Xamarin across.