### PR TITLE
add powershell category filter to author file

### DIFF
--- a/src/Firehose.Web/Authors/JeremyMurrah.cs
+++ b/src/Firehose.Web/Authors/JeremyMurrah.cs
@@ -25,5 +25,9 @@ namespace Firehose.Web.Authors
         {
             get { yield return new Uri("https://murrahjm.github.io/feed.xml"); }
         }
+        public bool Filter(SyndicationItem item)
+        {
+            return item.Categories.Where(i => i.Name.Equals("powershell", StringComparison.OrdinalIgnoreCase)).Any();
+        }
     }
 }


### PR DESCRIPTION
<!--
If you are submitting a new blog please read and check the boxes below.
 -->

:pencil2: **Blog Url**: <!-- example: https://example.com -->

:scroll: **Feed Url**: <!-- example: https://example.com/feed.rss -->

By sending this pull request to add my blog I verify that I adhere to the Planet PowerShell blog guidelines (please check each item that applies):

- [ ] I have a valid blog & RSS URL, both using HTTPS :lock: with a valid certificate
- [ ] I host NO malicious or offensive content on the blog (including photos, swearing, etc.)
- [ ] My blog is active with at least 3 PowerShell related blog posts in the last 6 months
- [ ] In addition to the previous guideline; it should be apperant that the blog is active for a longer period of time and the posts on it are not fabricated in a small amount of time to comply to the '3 posts in last 6 months' guideline.
- [ ] I have applied a filter.
- [ ] I have implemented `IAmACommunityMember` or one of the other derivatives
- [ ] I understand, if I delete my blog, I will be deleted from Planet PowerShell
- [ ] I understand, my blog may be removed at any time if any of these guidelines are broken.
- [ ] The submitted blog is not owned by a company which sole purpose it is to advertise a product of productline.

Only the collaborators of this repository decide whether a blog is eligible or not. They will determine if the rules are followed and if the quality of the content is high enough. 

Opening another PR, after the first one is closed in a small period of time will not be reevaluated. If a PR is closed, the issues with your blog are too significant to be fixed within a matter of hours.
